### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,69 @@
-# Hanami
+# Lotus
 
-The web, with simplicity.
+A complete web framework for Ruby
 
 ## Frameworks
 
-Hanami combines small yet powerful frameworks:
+Lotus combines small yet powerful frameworks:
 
-* [**Hanami::Utils**](https://github.com/hanami/utils) - Ruby core extensions and class utilities
-* [**Hanami::Router**](https://github.com/hanami/router) - Rack compatible HTTP router for Ruby
-* [**Hanami::Validations**](https://github.com/hanami/validations) - Validations mixin for Ruby objects
-* [**Hanami::Helpers**](https://github.com/hanami/helpers) - View helpers for Ruby applications
-* [**Hanami::Mailer**](https://github.com/hanami/mailer) - Mail for Ruby applications
-* [**Hanami::Model**](https://github.com/hanami/model) - Persistence with entities, repositories and data mapper
-* [**Hanami::Assets**](https://github.com/hanami/assets) - Assets management for Ruby
-* [**Hanami::View**](https://github.com/hanami/view) - Presentation with a separation between views and templates
-* [**Hanami::Controller**](https://github.com/hanami/controller) - Full featured, fast and testable actions for Rack
+* [**Lotus::Utils**](https://github.com/hanami/utils) - Ruby core extensions and class utilities
+* [**Lotus::Router**](https://github.com/hanami/router) - Rack compatible HTTP router for Ruby
+* [**Lotus::Validations**](https://github.com/hanami/validations) - Validations mixin for Ruby objects
+* [**Lotus::Helpers**](https://github.com/hanami/helpers) - View helpers for Ruby applications
+* [**Lotus::Mailer**](https://github.com/hanami/mailer) - Mail for Ruby applications
+* [**Lotus::Model**](https://github.com/hanami/model) - Persistence with entities, repositories and data mapper
+* [**Lotus::Assets**](https://github.com/hanami/assets) - Assets management for Ruby
+* [**Lotus::View**](https://github.com/hanami/view) - Presentation with a separation between views and templates
+* [**Lotus::Controller**](https://github.com/hanami/controller) - Full featured, fast and testable actions for Rack
 
-These components are designed to be used independently or together in a Hanami application.
+These components are designed to be used independently or together in a Lotus application.
 If you aren't familiar with them, please take time to go through their READMEs.
 
 ## Status
 
-[![Gem Version](https://badge.fury.io/rb/hanami.svg)](http://badge.fury.io/rb/hanami)
-[![Build Status](https://secure.travis-ci.org/hanami/hanami.svg?branch=master)](http://travis-ci.org/hanami/hanami?branch=master)
-[![Coverage](https://coveralls.io/repos/hanami/hanami/badge.svg?branch=master)](https://coveralls.io/r/hanami/hanami)
-[![Code Climate](https://codeclimate.com/github/hanami/hanami.svg)](https://codeclimate.com/github/hanami/hanami)
-[![Dependencies](https://gemnasium.com/hanami/hanami.svg)](https://gemnasium.com/hanami/hanami)
-[![Inline docs](http://inch-ci.org/github/hanami/hanami.svg)](http://inch-ci.org/github/hanami/hanami)
+[![Gem Version](https://badge.fury.io/rb/lotusrb.svg)](http://badge.fury.io/rb/lotusrb)
+[![Build Status](https://secure.travis-ci.org/lotus/lotus.svg?branch=master)](http://travis-ci.org/lotus/lotus?branch=master)
+[![Coverage](https://coveralls.io/repos/lotus/lotus/badge.svg?branch=master)](https://coveralls.io/r/lotus/lotus)
+[![Code Climate](https://codeclimate.com/github/lotus/lotus.svg)](https://codeclimate.com/github/lotus/lotus)
+[![Dependencies](https://gemnasium.com/lotus/lotus.svg)](https://gemnasium.com/lotus/lotus)
+[![Inline docs](http://inch-ci.org/github/lotus/lotus.svg)](http://inch-ci.org/github/lotus/lotus)
 
 ## Contact
 
-* Home page: http://hanamirb.org
-* Community: http://hanamirb.org/community
-* Guides: http://hanamirb.org/guides
-* Mailing List: http://hanamirb.org/mailing-list
-* API Doc: http://rdoc.info/gems/hanami
-* Bugs/Issues: https://github.com/hanami/hanami/issues
-* Support: http://stackoverflow.com/questions/tagged/hanami
-* Forum: https://discuss.hanamirb.org
-* Chat: http://chat.hanamirb.org
+* Home page: http://lotusrb.org
+* Community: http://lotusrb.org/community
+* Guides: http://lotusrb.org/guides
+* Mailing List: http://lotusrb.org/mailing-list
+* API Doc: http://www.rubydoc.info/gems/lotusrb
+* Bugs/Issues: https://github.com/hanami/lotus/issues
+* Support: http://stackoverflow.com/questions/tagged/lotus-ruby
+* Forum: https://discuss.lotusrb.org
+* Chat: http://chat.lotusrb.org
 
 ## Rubies
 
-__Hanami__ supports Ruby (MRI) 2+
+__Lotus__ supports Ruby (MRI) 2+
 
 ## Installation
 
 ```shell
-% gem install hanami
+% gem install lotusrb
 ```
 
 ## Usage
 
 ```shell
-% hanami new bookshelf
+% lotus new bookshelf
 % cd bookshelf && bundle
-% bundle exec hanami server # visit http://localhost:2300
+% bundle exec lotus server # visit http://localhost:2300
 ```
 
-Please follow along with the [Getting Started guide](http://hanamirb.org/guides/getting-started).
+Please follow along with the [Getting Started guide](http://lotusrb.org/guides/getting-started).
 
 ## Community
 
 We strive for a Community made of **inclusive, helpful and smart people**.
-We have a [Code of Conduct](http://hanamirb.org/community/#code-of-conduct) to handle controversial cases.
+We have a [Code of Conduct](http://lotusrb.org/community/#code-of-conduct) to handle controversial cases.
 In general, we expect **you** to be **nice** with other people.
 Our hope is for a great software and a great Community.
 
@@ -85,7 +85,7 @@ This Code of Conduct is adapted from the Contributor Covenant, version 1.1.0, av
 
 ## Contributing
 
-1. Fork it ( https://github.com/hanami/hanami/fork )
+1. Fork it ( https://github.com/lotus/lotus/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
@@ -93,9 +93,8 @@ This Code of Conduct is adapted from the Contributor Covenant, version 1.1.0, av
 
 ## Versioning
 
-__Hanami__ uses [Semantic Versioning 2.0.0](http://semver.org)
+__Lotus__ uses [Semantic Versioning 2.0.0](http://semver.org)
 
 ## Copyright
 
 Copyright © 2014-2016 Luca Guidi – Released under MIT License
-This project was formerly known as Lotus (`lotusrb`).


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/lotus/assets | https://github.com/hanami/assets 
https://github.com/lotus/controller | https://github.com/hanami/controller 
https://github.com/lotus/helpers | https://github.com/hanami/helpers 
https://github.com/lotus/lotus/issues | https://github.com/hanami/lotus/issues 
https://github.com/lotus/mailer | https://github.com/hanami/mailer 
https://github.com/lotus/model | https://github.com/hanami/model 
https://github.com/lotus/router | https://github.com/hanami/router 
https://github.com/lotus/utils | https://github.com/hanami/utils 
https://github.com/lotus/validations | https://github.com/hanami/validations 
https://github.com/lotus/view | https://github.com/hanami/view 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://rdoc.info/gems/lotusrb | http://www.rubydoc.info/gems/lotusrb 
